### PR TITLE
add Growl notification helper

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -6,6 +6,10 @@ Fixed:
 * Force a chown of vendor/bundler, since building gems sometimes doesn't preserve group permissions.
   Hopefully there will be a fix for this someday so we can avoid this workaround.
 
+Added:
+
+* Growl notification helper
+
 ## 0.5.7
 
 Changed:

--- a/README.rdoc
+++ b/README.rdoc
@@ -88,6 +88,15 @@ Run the gems:install rake task using sudo after deployment.
 Set git as the repository type, and set up remote caching to speed up
 deployments.
 
+=== growl
+
+Once the deploy is complete, this helper will post a message to Growl stating
+the application, the branch/tag and the environment. E.g.:
+
+  capistrano
+
+  finished deploying myapp v0.5.4 to staging
+
 === migrations
 
 Always run migrations during deployment.

--- a/lib/capistrano-helpers/growl.rb
+++ b/lib/capistrano-helpers/growl.rb
@@ -1,0 +1,22 @@
+require File.dirname(__FILE__) + '/../capistrano-helpers' if ! defined?(CapistranoHelpers)
+
+CapistranoHelpers.with_configuration do
+ 
+  namespace :deploy do
+    desc "Send a notification to Growl once deploy is complete, if available"
+    task :growl_notify do
+      if ! exists?(:application)
+        puts "You should set :application to the name of this app."
+      end
+
+      # If the :branch reference is a full SHA1, display it in its abbreviated form
+      growl_branch = fetch(:branch).sub(/\b([a-f0-9]{7})[a-f0-9]{33}\b/, '\1')
+      target = fetch(:stage, 'production')
+
+      system %{growlnotify -n "capistrano" -m "finished deploying #{application} #{growl_branch} to #{target}"}
+    end
+  end
+
+  after "deploy:restart", "deploy:growl_notify"
+
+end


### PR DESCRIPTION
This will send a message to Growl when the deploy is complete if installed; ignored otherwise.

I stole the application/branch/target code from the [campfire notifier](https://github.com/westarete/capistrano-helpers/blob/master/lib/capistrano-helpers/campfire.rb) so maybe there's a good way to share that logic, but I couldn't decide on the best way to create the helpers.
