### PR TITLE
add Ding notifier

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -6,6 +6,10 @@ Fixed:
 * Force a chown of vendor/bundler, since building gems sometimes doesn't preserve group permissions.
   Hopefully there will be a fix for this someday so we can avoid this workaround.
 
+Added:
+
+* Ding notifier
+
 ## 0.5.7
 
 Changed:

--- a/README.rdoc
+++ b/README.rdoc
@@ -73,6 +73,10 @@ E.g. in config/deploy/staging:
 
   set :campfire_notifications, false
 
+=== ding
+
+Once the deploy is complete, this helper will play a 'ding' sound (Mac only).
+
 === features
 
 Before the app is deployed, this helper checks out the branch/tag that is

--- a/lib/capistrano-helpers/ding.rb
+++ b/lib/capistrano-helpers/ding.rb
@@ -1,0 +1,14 @@
+require File.dirname(__FILE__) + '/../capistrano-helpers' if ! defined?(CapistranoHelpers)
+
+CapistranoHelpers.with_configuration do
+
+  namespace :deploy do
+    desc "Play a 'ding' sound once deploy is complete (Mac only)"
+    task :ding_notify do
+      system 'afplay /System/Library/Sounds/Glass.aiff'
+    end
+  end
+
+  after "deploy:restart", "deploy:ding_notify"
+
+end


### PR DESCRIPTION
Play a 'ding' sound when the deploy is complete.  It's currently Mac only (will fail silently on others), though maybe there's a consistent way to do this on Linux.
