### PR TITLE
make tinder gem an optional dependency

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -5,6 +5,7 @@ Fixed:
 * Campfire notifications were broken. Updated for new API, use git names for announcements.
 * Force a chown of vendor/bundler, since building gems sometimes doesn't preserve group permissions.
   Hopefully there will be a fix for this someday so we can avoid this workaround.
+* Only require tinder gem when using campfire helper, to reduce size of installation.
 
 ## 0.5.7
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -54,8 +54,10 @@ to your deploy script:
 
   before "deploy", "deploy:post_to_campfire_before"
 
-This helper expects to find a configuration file config/campfire.yml or ~/.campfire.yml
-with the following format:
+You will need to install the tinder gem to enable campfire notifications.  Run
+<tt>sudo gem install tinder</tt>, or add <tt>gem 'tinder'</tt> to your Gemfile.
+This helper expects to find a configuration file config/campfire.yml or
+~/.campfire.yml with the following format:
 
   # Configuration for posting to campfire.
   subdomain: mycompany

--- a/Rakefile
+++ b/Rakefile
@@ -12,7 +12,6 @@ begin
     gem.authors = ["Scott Woods", "Clinton Judy"]
     gem.add_dependency('capistrano')
     gem.add_dependency('git')
-    gem.add_dependency('tinder')
   end
 
 rescue LoadError
@@ -41,7 +40,7 @@ end
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   if File.exist?('VERSION.yml')
     config = YAML.load(File.read('VERSION.yml'))

--- a/capistrano-helpers.gemspec
+++ b/capistrano-helpers.gemspec
@@ -4,14 +4,14 @@
 # -*- encoding: utf-8 -*-
 
 Gem::Specification.new do |s|
-  s.name = %q{capistrano-helpers}
+  s.name = "capistrano-helpers"
   s.version = "0.7.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Scott Woods", "Clinton Judy"]
-  s.date = %q{2012-04-16}
-  s.description = %q{A set of optional extensions to capistrano to make common tasks easier.}
-  s.email = %q{team@westarete.com}
+  s.date = "2013-01-20"
+  s.description = "A set of optional extensions to capistrano to make common tasks easier."
+  s.email = "team@westarete.com"
   s.extra_rdoc_files = [
     "LICENSE",
     "README.rdoc"
@@ -39,31 +39,28 @@ Gem::Specification.new do |s|
     "lib/capistrano-helpers/shared.rb",
     "lib/capistrano-helpers/skylinecms.rb",
     "lib/capistrano-helpers/specs.rb",
+    "lib/capistrano-helpers/unicorn.rb",
     "lib/capistrano-helpers/version.rb",
     "test/test_helper.rb"
   ]
-  s.homepage = %q{http://github.com/westarete/capistrano-helpers}
+  s.homepage = "http://github.com/westarete/capistrano-helpers"
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.3.6}
-  s.summary = %q{A set of optional extensions to capistrano to make common tasks easier.}
+  s.rubygems_version = "1.8.24"
+  s.summary = "A set of optional extensions to capistrano to make common tasks easier."
 
   if s.respond_to? :specification_version then
-    current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 3
 
-    if Gem::Version.new(Gem::RubyGemsVersion) >= Gem::Version.new('1.2.0') then
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<capistrano>, [">= 0"])
       s.add_runtime_dependency(%q<git>, [">= 0"])
-      s.add_runtime_dependency(%q<tinder>, [">= 0"])
     else
       s.add_dependency(%q<capistrano>, [">= 0"])
       s.add_dependency(%q<git>, [">= 0"])
-      s.add_dependency(%q<tinder>, [">= 0"])
     end
   else
     s.add_dependency(%q<capistrano>, [">= 0"])
     s.add_dependency(%q<git>, [">= 0"])
-    s.add_dependency(%q<tinder>, [">= 0"])
   end
 end
 

--- a/lib/capistrano-helpers/campfire.rb
+++ b/lib/capistrano-helpers/campfire.rb
@@ -1,6 +1,11 @@
 require File.dirname(__FILE__) + '/../capistrano-helpers' if ! defined?(CapistranoHelpers)
 
-require 'tinder'
+begin
+  require 'tinder'
+rescue LoadError
+  raise RuntimeError, "tinder gem required for Campfire deploy notifications.  Run `sudo gem install tinder`, or add `gem 'tinder'` to your Gemfile."
+end
+
 require 'git'
 
 CapistranoHelpers.with_configuration do


### PR DESCRIPTION
We don't use Campfire, and having to install the tinder gem when using capistrano-helpers adds a lot of cruft.  With this change, it won't be installed as part of the gem dependencies, but an error with instructions will be thrown if someone tries to use the Campfire notifier and tinder isn't available.
